### PR TITLE
setup landing page to use templates

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: tildy.dev
+title: The Lovely Developers
 email: 
 description: >-
 baseurl: ""

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,0 +1,46 @@
+<head>
+    <!-- meta and open graph tags https://ogp.me/ -->
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta content="{{ site.title }}" property="og:site_name">
+    {% if page.title %}
+    <meta content="{{ page.title }}" property="og:title">
+    {% else %}
+    <meta content="{{ site.title }}" property="og:title">
+    {% endif %}
+    {% if page.title %}
+    <meta content="article" property="og:type">
+    {% else %}
+    <meta content="website" property="og:type">
+    {% endif %}
+    {% if page.excerpt %}
+    <meta content="{{ page.excerpt | strip_html }}" property="og:description">
+    {% elsif page.description %}
+    <meta content="{{ page.description | strip_html }}" property="og:description">
+    {% else %}
+    <meta content="{{ site.description }}" property="og:description">
+    {% endif %}
+    {% if page.url %}
+    <meta content="{{ site.url }}{{ page.url }}" property="og:url">
+    {% endif %}
+    {% if page.date %}
+    <meta content="{{ page.date | date_to_xmlschema }}" property="article:published_time">
+    <meta content="{{ site.url }}" property="article:author">
+    {% endif %}
+    {% if page.categories %}
+    {% for category in page.categories limit:1 %}
+    <meta content="{{ category }}" property="article:section">
+    {% endfor %}
+    {% endif %}
+    {% if page.tags %}
+    {% for tag in page.tags %}
+    <meta content="{{ tag }}" property="article:tag">
+    {% endfor %}
+    {% endif %}
+    <title>{% if page.title %}{{ page.title | escape }} - {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+    <!-- css -->
+    <link rel="stylesheet" type="text/css" href="/css/style.css">
+    <!-- js -->
+    <script type="text/javascript" src="/js/scripts.js"></script>
+</head>

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+{% include head.html %}
+
+<body>
+    {{content}}
+</body>
+
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,20 +1,15 @@
-<html>
-	<head>
-		<title>The Lovely Developers</title>
-		<link rel="stylesheet" type="text/css" href="/css/style.css">
-		<script type="text/javascript" src="/js/scripts.js"></script>
-	</head>
-	<body onload="pageLoaded()">
-		<div id="container">
-			<div id="content">
-				<h1>We are <span id="title">The Lovely Developers</span>.</h1>
-				
-				<p>We're a group of friends around the world who make a few things, including:</p>
-				
-				<ul id="projects"></ul>
-				
-				<p id="members">We are some people.</p>
-			</div>
-		</div>
-	</body>
-</html>
+---
+layout: base
+---
+
+<div id="container">
+	<div id="content">
+		<h1>We are <span id="title">The Lovely Developers</span>.</h1>
+		
+		<p>We're a group of friends around the world who make a few things, including:</p>
+		
+		<ul id="projects"></ul>
+		
+		<p id="members">We are some people.</p>
+	</div>
+</div>

--- a/docs/js/scripts.js
+++ b/docs/js/scripts.js
@@ -53,7 +53,7 @@ function getMembers() {
 	});
 }
 
-function pageLoaded() {
+window.onload = function() {
 	getMembers();
 	getProjects();
 }


### PR DESCRIPTION
Using Jekyll's `_layouts` and `_includes` to separate out the head section from the landing page. Currently, this doesn't really do much for us, but it will allow us to reuse these components in the future on other pages.

Resolves #14 